### PR TITLE
chore: remove invalid omitempty field

### DIFF
--- a/pkg/apis/jenkins.io/v1/types_release.go
+++ b/pkg/apis/jenkins.io/v1/types_release.go
@@ -153,7 +153,7 @@ type DependencyUpdateDetails struct {
 	Host               string `json:"host"`
 	Owner              string `json:"owner"`
 	Repo               string `json:"repo"`
-	Component          string `json:"component,omitempty"`
+	Component          string `json:"component"`
 	URL                string `json:"url"`
 	FromVersion        string `json:"fromVersion"`
 	FromReleaseHTMLURL string `json:"fromReleaseHTMLURL"`


### PR DESCRIPTION
In jx-api, the linter picked up the original invalid tag of `json:"component, omitempty"`.
The test cases in JX prove that this was never working, so we are aligining the codebase with
what is currently working in the wild.