### PR TITLE
chore: add a const for the default jx namespace

### DIFF
--- a/pkg/apis/core/v4beta1/requirements.go
+++ b/pkg/apis/core/v4beta1/requirements.go
@@ -37,6 +37,9 @@ const (
 
 	constTrue  = "true"
 	constFalse = "false"
+
+	// Replaces the optional requirement and making jx hardcoded, if folks try changing the namespace in a jx-requirements.yml file it is highly likely to fail
+	DefaultNamespace = "jx"
 )
 
 const (


### PR DESCRIPTION
This replaces the old jx requirement for namespace, if folks did try changing the namespace in a jx-requirements.yml file it is highly likely to fail