### PR TITLE
feat: added extraDomains to ingress config

### DIFF
--- a/pkg/apis/core/v4beta1/requirements.go
+++ b/pkg/apis/core/v4beta1/requirements.go
@@ -230,6 +230,8 @@ type IngressConfig struct {
 	CloudDNSSecretName string `json:"cloud_dns_secret_name,omitempty"`
 	// Domain to expose ingress endpoints
 	Domain string `json:"domain"`
+	// Extra domains to expose alternate endpoints with custom ingress
+	ExtraDomains []string `json:"extraDomains,omitempty"`
 	// Kind the kind of ingress used (ingress v1, ingress v2, istio etc)
 	Kind IngressType `json:"kind,omitempty"`
 	// IgnoreLoadBalancer if the nginx-controller LoadBalancer service should not be used to detect and update the

--- a/pkg/apis/core/v4beta1/requirements_test.go
+++ b/pkg/apis/core/v4beta1/requirements_test.go
@@ -35,6 +35,7 @@ func TestRequirementsConfigMarshalExistingFile(t *testing.T) {
 	expectedClusterName := "my-cluster"
 	expectedSecretStorage := v4beta1.SecretStorageTypeVault
 	expectedDomain := "cheese.co.uk"
+	expectedExtraDomains := []string{"wine.com", "grapes.org.uk"}
 	expectedPipelineUserName := "someone"
 	expectedPipelineUserEmail := "someone@acme.com"
 
@@ -44,6 +45,7 @@ func TestRequirementsConfigMarshalExistingFile(t *testing.T) {
 	requirements.SecretStorage = expectedSecretStorage
 	requirements.Cluster.ClusterName = expectedClusterName
 	requirements.Ingress.Domain = expectedDomain
+	requirements.Ingress.ExtraDomains = expectedExtraDomains
 	requirements.PipelineUser = &v4beta1.UserNameEmailConfig{
 		Username: expectedPipelineUserName,
 		Email:    expectedPipelineUserEmail,
@@ -59,6 +61,7 @@ func TestRequirementsConfigMarshalExistingFile(t *testing.T) {
 	assert.Equal(t, expectedClusterName, requirements.Cluster.ClusterName, "requirements.ClusterName")
 	assert.Equal(t, expectedSecretStorage, requirements.SecretStorage, "requirements.SecretStorage")
 	assert.Equal(t, expectedDomain, requirements.Ingress.Domain, "requirements.Domain")
+	assert.Equal(t, expectedExtraDomains, requirements.Ingress.ExtraDomains, "requirements.extraDomains")
 }
 
 func Test_OverrideRequirementsFromEnvironment_does_not_initialise_nil_structs(t *testing.T) {

--- a/schema/core.jenkins-x.io/v4beta1/requirements.json
+++ b/schema/core.jenkins-x.io/v4beta1/requirements.json
@@ -210,6 +210,12 @@
         "domain": {
           "type": "string"
         },
+        "extraDomains": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
         "externalDNS": {
           "type": "boolean"
         },


### PR DESCRIPTION
This is to facilitate extra domains with default support from jenkins-x with as few customizations as possible