### PR TITLE
fix: make extraDomains cleaner and less confusing

### DIFF
--- a/pkg/apis/core/v4beta1/requirements.go
+++ b/pkg/apis/core/v4beta1/requirements.go
@@ -230,8 +230,6 @@ type IngressConfig struct {
 	CloudDNSSecretName string `json:"cloud_dns_secret_name,omitempty"`
 	// Domain to expose ingress endpoints
 	Domain string `json:"domain"`
-	// Extra domains to expose alternate endpoints with custom ingress
-	ExtraDomains []string `json:"extraDomains,omitempty"`
 	// Kind the kind of ingress used (ingress v1, ingress v2, istio etc)
 	Kind IngressType `json:"kind,omitempty"`
 	// IgnoreLoadBalancer if the nginx-controller LoadBalancer service should not be used to detect and update the
@@ -521,6 +519,8 @@ type RequirementsConfig struct {
 	Cluster ClusterConfig `json:"cluster"`
 	// Environments the requirements for the environments
 	Environments []EnvironmentConfig `json:"environments,omitempty"`
+	// ExtraDomains to expose alternate services with custom ingress for specific applications
+	ExtraDomains []IngressConfig `json:"extraDomains,omitempty"`
 	// Ingress contains ingress specific requirements
 	Ingress IngressConfig `json:"ingress"`
 	// Kuberhealthy indicates if we have already installed Kuberhealthy upfront in the kubernetes cluster

--- a/pkg/apis/core/v4beta1/requirements_test.go
+++ b/pkg/apis/core/v4beta1/requirements_test.go
@@ -35,9 +35,21 @@ func TestRequirementsConfigMarshalExistingFile(t *testing.T) {
 	expectedClusterName := "my-cluster"
 	expectedSecretStorage := v4beta1.SecretStorageTypeVault
 	expectedDomain := "cheese.co.uk"
-	expectedExtraDomains := []string{"wine.com", "grapes.org.uk"}
 	expectedPipelineUserName := "someone"
 	expectedPipelineUserEmail := "someone@acme.com"
+	expectedExtraDomains := []v4beta1.IngressConfig{{
+		Domain: "wine.com",
+		TLS: &v4beta1.TLSConfig{
+			Enabled:    true,
+			Production: true,
+		},
+	}, {
+		Domain: "grapes.org.uk",
+		TLS: &v4beta1.TLSConfig{
+			Enabled:    true,
+			Production: false,
+		},
+	}}
 
 	file := filepath.Join(dir, v4beta1.RequirementsConfigFileName)
 	requirementResource := v4beta1.NewRequirementsConfig()
@@ -45,7 +57,7 @@ func TestRequirementsConfigMarshalExistingFile(t *testing.T) {
 	requirements.SecretStorage = expectedSecretStorage
 	requirements.Cluster.ClusterName = expectedClusterName
 	requirements.Ingress.Domain = expectedDomain
-	requirements.Ingress.ExtraDomains = expectedExtraDomains
+	requirements.ExtraDomains = expectedExtraDomains
 	requirements.PipelineUser = &v4beta1.UserNameEmailConfig{
 		Username: expectedPipelineUserName,
 		Email:    expectedPipelineUserEmail,
@@ -61,7 +73,7 @@ func TestRequirementsConfigMarshalExistingFile(t *testing.T) {
 	assert.Equal(t, expectedClusterName, requirements.Cluster.ClusterName, "requirements.ClusterName")
 	assert.Equal(t, expectedSecretStorage, requirements.SecretStorage, "requirements.SecretStorage")
 	assert.Equal(t, expectedDomain, requirements.Ingress.Domain, "requirements.Domain")
-	assert.Equal(t, expectedExtraDomains, requirements.Ingress.ExtraDomains, "requirements.extraDomains")
+	assert.Equal(t, expectedExtraDomains, requirements.ExtraDomains, "requirements.extraDomains")
 }
 
 func Test_OverrideRequirementsFromEnvironment_does_not_initialise_nil_structs(t *testing.T) {

--- a/schema/core.jenkins-x.io/v4beta1/requirements.json
+++ b/schema/core.jenkins-x.io/v4beta1/requirements.json
@@ -210,12 +210,6 @@
         "domain": {
           "type": "string"
         },
-        "extraDomains": {
-          "items": {
-            "type": "string"
-          },
-          "type": "array"
-        },
         "externalDNS": {
           "type": "boolean"
         },
@@ -266,6 +260,13 @@
           "items": {
             "$schema": "http://json-schema.org/draft-04/schema#",
             "$ref": "#/definitions/EnvironmentConfig"
+          },
+          "type": "array"
+        },
+        "extraDomains": {
+          "items": {
+            "$schema": "http://json-schema.org/draft-04/schema#",
+            "$ref": "#/definitions/IngressConfig"
           },
           "type": "array"
         },


### PR DESCRIPTION
Because extraDomains was in the ingress config, this meant that it created confusion to anyone that wanted to use environment, as environments would have extraDomains as well as the standard ingress.

To resolve this, I've moved extra domains higher up within the root requirements each with their own ingress config.

If we're happy with this, I'll fix up ExternalDNS versioning and the acme chart to use this correctly.

