### PR TITLE
fix: add comments to the types for description

### DIFF
--- a/pkg/apis/jenkins.io/v1/types_pipeline.go
+++ b/pkg/apis/jenkins.io/v1/types_pipeline.go
@@ -182,9 +182,10 @@ const (
 	ActivityStepKindTypePromote ActivityStepKindType = "Promote"
 )
 
-// ActivityStatusType is the status of an activity; usually succeeded or failed/error on completion
 type (
-	ActivityStatusType  string
+	// ActivityStatusType is the status of an activity; usually succeeded or failed/error on completion
+	ActivityStatusType string
+	// ActivityMessageType is the message of an activity; usually succeeded or failed/error on completion
 	ActivityMessageType string
 )
 


### PR DESCRIPTION
This PR add comments above ActivityStatusType and ActivityMessageType to generate desciptions in the crd.yaml files.
They were removed in the last commit.
New manifests are added to jenkins-s-crds repo.