### PR TITLE
Optionally validate with AllowAdditionalProperties

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,14 +1,4 @@
 approvers:
-- rawlingsj
-- jstrachan
-- ankitm123
-- babadofar
-- tomhobson
-- garethjevans
+- maintainers
 reviewers:
-- rawlingsj
-- jstrachan
-- ankitm123
-- babadofar
-- tomhobson
-- garethjevans
+- maintainers

--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -1,0 +1,2 @@
+foreignAliases:
+- name: jx-community

--- a/pkg/schemagen/schemagen.go
+++ b/pkg/schemagen/schemagen.go
@@ -4,12 +4,13 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"github.com/jenkins-x/jx-api/v4/pkg/util"
-	"github.com/jenkins-x/jx-logging/v3/pkg/log"
-	"github.com/pkg/errors"
 	"io/ioutil"
 	"os"
 	"path/filepath"
+
+	"github.com/jenkins-x/jx-api/v4/pkg/util"
+	"github.com/jenkins-x/jx-logging/v3/pkg/log"
+	"github.com/pkg/errors"
 )
 
 const (
@@ -45,7 +46,7 @@ func GenerateSchemas(resourceKinds []ResourceKind, out string) error {
 
 // Generate generates the schema document
 func generate(schemaName string, out string, schemaTarget interface{}) error {
-	schema := util.GenerateSchema(schemaTarget)
+	schema := util.GenerateSchema(schemaTarget, false)
 	if schema == nil {
 		return fmt.Errorf("could not generate schema for %s", schemaName)
 	}

--- a/pkg/util/validation.go
+++ b/pkg/util/validation.go
@@ -8,12 +8,12 @@ import (
 )
 
 // GenerateSchema generates a JSON schema for the given struct type and returns it.
-func GenerateSchema(target interface{}) *schemagen.Schema {
+func GenerateSchema(target interface{}, allowAdditionalProperties bool) *schemagen.Schema {
 	reflector := schemagen.Reflector{
 		IgnoredTypes: []interface{}{
 			corev1.Container{},
 		},
-
+		AllowAdditionalProperties: allowAdditionalProperties,
 		//ExpandedStruct: true,
 		RequiredFromJSONSchemaTags: true,
 	}
@@ -23,7 +23,13 @@ func GenerateSchema(target interface{}) *schemagen.Schema {
 // ValidateYaml generates a JSON schema for the given struct type, and then validates the given YAML against that
 // schema, ignoring Containers and missing fields.
 func ValidateYaml(target interface{}, data []byte) ([]string, error) {
-	schema := GenerateSchema(target)
+	return ValidateYamlLenient(target, data, false)
+}
+
+// ValidateYamlLenient generates a JSON schema for the given struct type, and then validates the given YAML against that
+// schema, ignoring Containers and missing fields. If allowAdditionalProperties is true additional keys in JSON objects are allowed.
+func ValidateYamlLenient(target interface{}, data []byte, allowAdditionalProperties bool) ([]string, error) {
+	schema := GenerateSchema(target, allowAdditionalProperties)
 	dataAsJSON, err := yaml.YAMLToJSON(data)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Using AllowAdditionalProperties makes it easier to introduce new fields in resources used by several application without having to upgrade jx-api in all files using the file. Like in `.jx/settings.yaml`.