### PR TITLE
feat: add cluster nodes rsg client ID to jx-requirements

### DIFF
--- a/pkg/apis/core/v4beta1/requirements.go
+++ b/pkg/apis/core/v4beta1/requirements.go
@@ -283,14 +283,19 @@ type AzureStorageConfig struct {
 	StorageAccountName string `json:"storageAccountName,omitempty"`
 }
 
+type AzureClusterNodesConfig struct {
+	ClientID string `json:"clientID"`
+}
+
 // AzureConfig contains Azure specific requirements
 type AzureConfig struct {
 	// RegistrySubscription the registry subscription for defaulting the container registry.
 	// Not used if you specify a Registry explicitly
-	RegistrySubscription     string              `json:"registrySubscription,omitempty"`
-	AzureDNSConfig           *AzureDNSConfig     `json:"dns,omitempty"`
-	AzureSecretStorageConfig *AzureSecretConfig  `json:"secretStorage,omitempty"`
-	AzureStorageConfig       *AzureStorageConfig `json:"storage,omitempty"`
+	RegistrySubscription     string                   `json:"registrySubscription,omitempty"`
+	AzureDNSConfig           *AzureDNSConfig          `json:"dns,omitempty"`
+	AzureSecretStorageConfig *AzureSecretConfig       `json:"secretStorage,omitempty"`
+	AzureStorageConfig       *AzureStorageConfig      `json:"storage,omitempty"`
+	AzureClusterNodesConfig  *AzureClusterNodesConfig `json:"clusterNodes,omitempty"`
 }
 
 // GKEConfig contains GKE specific requirements

--- a/schema/core.jenkins-x.io/v4beta1/requirements.json
+++ b/schema/core.jenkins-x.io/v4beta1/requirements.json
@@ -17,8 +17,21 @@
       "additionalProperties": false,
       "type": "object"
     },
+    "AzureClusterNodesConfig": {
+      "properties": {
+        "clientID": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
+    },
     "AzureConfig": {
       "properties": {
+        "clusterNodes": {
+          "$schema": "http://json-schema.org/draft-04/schema#",
+          "$ref": "#/definitions/AzureClusterNodesConfig"
+        },
         "dns": {
           "$schema": "http://json-schema.org/draft-04/schema#",
           "$ref": "#/definitions/AzureDNSConfig"
@@ -123,6 +136,10 @@
           "$schema": "http://json-schema.org/draft-04/schema#",
           "$ref": "#/definitions/GKEConfig"
         },
+        "issueProvider": {
+          "$schema": "http://json-schema.org/draft-04/schema#",
+          "$ref": "#/definitions/IssueTracker"
+        },
         "kanikoFlags": {
           "type": "string"
         },
@@ -180,6 +197,9 @@
         },
         "repository": {
           "type": "string"
+        },
+        "reusePullRequest": {
+          "type": "boolean"
         }
       },
       "additionalProperties": false,
@@ -233,6 +253,53 @@
       "additionalProperties": false,
       "type": "object"
     },
+    "IssueTracker": {
+      "properties": {
+        "jira": {
+          "$schema": "http://json-schema.org/draft-04/schema#",
+          "$ref": "#/definitions/JiraTracker"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
+    },
+    "JiraTracker": {
+      "properties": {
+        "project": {
+          "type": "string"
+        },
+        "serverUrl": {
+          "type": "string"
+        },
+        "userName": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
+    },
+    "MavenRepositoryConfig": {
+      "properties": {
+        "releaseUrl": {
+          "type": "string"
+        },
+        "snapshotUrl": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
+    },
+    "RepositoryConfig": {
+      "properties": {
+        "maven": {
+          "$schema": "http://json-schema.org/draft-04/schema#",
+          "$ref": "#/definitions/MavenRepositoryConfig"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
+    },
     "Requirements": {
       "properties": {
         "apiVersion": {
@@ -281,6 +348,10 @@
         "pipelineUser": {
           "$schema": "http://json-schema.org/draft-04/schema#",
           "$ref": "#/definitions/UserNameEmailConfig"
+        },
+        "repositories": {
+          "$schema": "http://json-schema.org/draft-04/schema#",
+          "$ref": "#/definitions/RepositoryConfig"
         },
         "repository": {
           "type": "string"

--- a/schema/jenkins.io/v1/environment.json
+++ b/schema/jenkins.io/v1/environment.json
@@ -582,9 +582,6 @@
     },
     "EphemeralVolumeSource": {
       "properties": {
-        "readOnly": {
-          "type": "boolean"
-        },
         "volumeClaimTemplate": {
           "$schema": "http://json-schema.org/draft-04/schema#",
           "$ref": "#/definitions/PersistentVolumeClaimTemplate"
@@ -923,6 +920,9 @@
         "backoffLimit": {
           "type": "integer"
         },
+        "completionMode": {
+          "type": "string"
+        },
         "completions": {
           "type": "integer"
         },
@@ -935,6 +935,9 @@
         "selector": {
           "$schema": "http://json-schema.org/draft-04/schema#",
           "$ref": "#/definitions/LabelSelector"
+        },
+        "suspend": {
+          "type": "boolean"
         },
         "template": {
           "$schema": "http://json-schema.org/draft-04/schema#",
@@ -951,6 +954,9 @@
       "properties": {
         "active": {
           "type": "integer"
+        },
+        "completedIndexes": {
+          "type": "string"
         },
         "completionTime": {
           "type": [
@@ -978,6 +984,10 @@
         },
         "succeeded": {
           "type": "integer"
+        },
+        "uncountedTerminatedPods": {
+          "$schema": "http://json-schema.org/draft-04/schema#",
+          "$ref": "#/definitions/UncountedTerminatedPods"
         }
       },
       "additionalProperties": false,
@@ -1075,6 +1085,9 @@
           "type": "string"
         },
         "operation": {
+          "type": "string"
+        },
+        "subresource": {
           "type": "string"
         },
         "time": {
@@ -1301,6 +1314,9 @@
           "$schema": "http://json-schema.org/draft-04/schema#",
           "$ref": "#/definitions/TypedLocalObjectReference"
         },
+        "dataSourceRef": {
+          "$ref": "#/definitions/TypedLocalObjectReference"
+        },
         "resources": {
           "$schema": "http://json-schema.org/draft-04/schema#",
           "$ref": "#/definitions/ResourceRequirements"
@@ -1381,6 +1397,9 @@
     "PodAffinityTerm": {
       "properties": {
         "labelSelector": {
+          "$ref": "#/definitions/LabelSelector"
+        },
+        "namespaceSelector": {
           "$ref": "#/definitions/LabelSelector"
         },
         "namespaces": {
@@ -1760,6 +1779,9 @@
         "tcpSocket": {
           "$schema": "http://json-schema.org/draft-04/schema#",
           "$ref": "#/definitions/TCPSocketAction"
+        },
+        "terminationGracePeriodSeconds": {
+          "type": "integer"
         },
         "timeoutSeconds": {
           "type": "integer"
@@ -2325,6 +2347,24 @@
       "additionalProperties": false,
       "type": "object"
     },
+    "UncountedTerminatedPods": {
+      "properties": {
+        "failed": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "succeeded": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
+    },
     "UserSpec": {
       "properties": {
         "imageUrl": {
@@ -2563,6 +2603,9 @@
         },
         "gmsaCredentialSpecName": {
           "type": "string"
+        },
+        "hostProcess": {
+          "type": "boolean"
         },
         "runAsUserName": {
           "type": "string"

--- a/schema/jenkins.io/v1/pipeline-activity.json
+++ b/schema/jenkins.io/v1/pipeline-activity.json
@@ -48,6 +48,9 @@
         "description": {
           "type": "string"
         },
+        "message": {
+          "type": "string"
+        },
         "name": {
           "type": "string"
         },
@@ -97,6 +100,9 @@
           "type": "string"
         },
         "operation": {
+          "type": "string"
+        },
+        "subresource": {
           "type": "string"
         },
         "time": {
@@ -306,6 +312,9 @@
         "lastCommitURL": {
           "type": "string"
         },
+        "message": {
+          "type": "string"
+        },
         "pipeline": {
           "type": "string"
         },
@@ -387,6 +396,9 @@
         "environment": {
           "type": "string"
         },
+        "message": {
+          "type": "string"
+        },
         "name": {
           "type": "string"
         },
@@ -423,6 +435,9 @@
           "type": "string"
         },
         "environment": {
+          "type": "string"
+        },
+        "message": {
           "type": "string"
         },
         "name": {
@@ -465,6 +480,9 @@
         "mergeCommitSHA": {
           "type": "string"
         },
+        "message": {
+          "type": "string"
+        },
         "name": {
           "type": "string"
         },
@@ -495,6 +513,9 @@
           "format": "date-time"
         },
         "description": {
+          "type": "string"
+        },
+        "message": {
           "type": "string"
         },
         "name": {
@@ -546,6 +567,9 @@
           "format": "date-time"
         },
         "description": {
+          "type": "string"
+        },
+        "message": {
           "type": "string"
         },
         "name": {

--- a/schema/jenkins.io/v1/release.json
+++ b/schema/jenkins.io/v1/release.json
@@ -220,6 +220,9 @@
         "operation": {
           "type": "string"
         },
+        "subresource": {
+          "type": "string"
+        },
         "time": {
           "type": [
             "string",

--- a/schema/jenkins.io/v1/source-repository.json
+++ b/schema/jenkins.io/v1/source-repository.json
@@ -24,6 +24,9 @@
         "operation": {
           "type": "string"
         },
+        "subresource": {
+          "type": "string"
+        },
         "time": {
           "type": [
             "string",


### PR DESCRIPTION
Adds the Client ID for the cluster nodes resource group to jx-requirements. This is needed for identifying which service principal to use when pushing containers to the registry (in the case where there are multiple principals).

https://github.com/jenkins-x/jx/issues/8580